### PR TITLE
Di 365 v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ DNAnexus workflow to generate bed files, coverage reports and Excel workbooks fo
 | generate_bed                    | 1.2.0    |
 | eggd_vep                        | 1.1.0  |
 | eggd_additional_cnv_tasks       | 1.0.1  |
-| eggd_generate_variant_workbook  | 2.2.0  |
+| eggd_generate_variant_workbook  | 2.5.0  |
 
 
 This workflow was made by EMEE GLH

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -27,7 +27,7 @@
     {
       "id": "stage-cnv_vep",
       "executable": "app-eggd_vep/1.1.0",
-      "noramlise": false,
+      "normalise": false,
       "input": {
         "panel_bed": {
           "$dnanexus_link": {

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -3,7 +3,7 @@
   "title": "dias_cnvreports_v1.0.2",
   "stages": [
     {
-      "id": "stage-GFZQB7Q4qq8X6yjKG2pFQ58x",
+      "id": "stage-cnv_generate_bed_excluded",
       "name": "generate_bed_for_excluded_annotation",
       "executable": "app-generate_bed/1.2.0",
       "input": {
@@ -11,30 +11,30 @@
       }
     },
     {
-      "id": "stage-GG39Gq04qq8ZkfgV31yQy93v",
+      "id": "stage-cnv_generate_bed_vep",
       "name": "generate_bed_for_vep",
       "executable": "app-generate_bed/1.2.0"
     },
     {
-      "id": "stage-GG1qYz84qq8yKzF1J2X48q62",
+      "id": "stage-cnv_annotate_excluded_regions",
       "executable": "app-eggd_annotate_excluded_regions/1.0.1",
       "input": {
         "panel_bed": {
           "$dnanexus_link": {
-            "stage": "stage-GFZQB7Q4qq8X6yjKG2pFQ58x",
+            "stage": "stage-cnv_generate_bed_excluded",
             "outputField": "bed_file"
           }
         }
       }
     },
     {
-      "id": "stage-GFYvJF04qq8VKgq34j30pZZ3",
+      "id": "stage-cnv_vep",
       "executable": "app-eggd_vep/1.1.0",
       "input": {
         "normalise": false,
         "panel_bed": {
           "$dnanexus_link": {
-            "stage": "stage-GG39Gq04qq8ZkfgV31yQy93v",
+            "stage": "stage-cnv_generate_bed_vep",
             "outputField": "bed_file"
           }
         }
@@ -51,14 +51,14 @@
       "input": {
         "vcf": {
           "$dnanexus_link": {
-            "stage": "stage-GFYvJF04qq8VKgq34j30pZZ3",
+            "stage": "stage-cnv_vep",
             "outputField": "annotated_vcf"
           }
         }
       }
     },
     {
-      "id": "stage-GFfYY9j4qq8ZxpFpP8zKG7G0",
+      "id": "stage-cnv_generate_workbook",
       "executable": "app-eggd_generate_variant_workbook/2.2.0",
       "input": {
         "additional_sheet_names": "ExcludedRegions",
@@ -73,7 +73,7 @@
         "additional_files": [
           {
             "$dnanexus_link": {
-              "stage": "stage-GG1qYz84qq8yKzF1J2X48q62",
+              "stage": "stage-cnv_annotate_excluded_regions",
               "outputField": "annotated_excluded_file"
             }
           }

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -59,7 +59,7 @@
     },
     {
       "id": "stage-cnv_generate_workbook",
-      "executable": "app-eggd_generate_variant_workbook/2.2.0",
+      "executable": "app-eggd_generate_variant_workbook/2.5.0",
       "input": {
         "additional_sheet_names": "ExcludedRegions",
         "vcfs": [

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -27,8 +27,8 @@
     {
       "id": "stage-cnv_vep",
       "executable": "app-eggd_vep/1.1.0",
-      "normalise": false,
       "input": {
+        "normalise": false,
         "panel_bed": {
           "$dnanexus_link": {
             "stage": "stage-cnv_generate_bed_vep",

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,14 +1,11 @@
 {
-  "name": "dias_cnvreports_v1.0.2",
-  "title": "dias_cnvreports_v1.0.2",
+  "name": "dias_cnvreports_v1.1.0",
+  "title": "dias_cnvreports_v1.1.0",
   "stages": [
     {
       "id": "stage-cnv_generate_bed_excluded",
       "name": "generate_bed_for_excluded_annotation",
-      "executable": "app-generate_bed/1.2.0",
-      "input": {
-        "flank": 0
-      }
+      "executable": "app-generate_bed/1.2.0"
     },
     {
       "id": "stage-cnv_generate_bed_vep",
@@ -30,8 +27,8 @@
     {
       "id": "stage-cnv_vep",
       "executable": "app-eggd_vep/1.1.0",
+      "noramlise": false,
       "input": {
-        "normalise": false,
         "panel_bed": {
           "$dnanexus_link": {
             "stage": "stage-cnv_generate_bed_vep",
@@ -46,7 +43,7 @@
       }
     },
     {
-      "id": "stage-GG2z5yQ4qq8vb2xp4pB8XByz",
+      "id": "stage-cnv_additional_tasks",
       "executable": "app-eggd_additional_cnv_tasks/1.0.1",
       "input": {
         "vcf": {
@@ -61,11 +58,10 @@
       "id": "stage-cnv_generate_workbook",
       "executable": "app-eggd_generate_variant_workbook/2.5.0",
       "input": {
-        "additional_sheet_names": "ExcludedRegions",
         "vcfs": [
           {
             "$dnanexus_link": {
-              "stage": "stage-GG2z5yQ4qq8vb2xp4pB8XByz",
+              "stage": "stage-cnv_additional_tasks",
               "outputField": "output_vcf"
             }
           }
@@ -77,11 +73,7 @@
               "outputField": "annotated_excluded_file"
             }
           }
-        ],
-        "exclude_columns": "REF FILTER CSQ_Allele CSQ_Consequence CSQ_IMPACT",
-        "reorder_columns": "CHROM POS END CNVLEN ID ALT QUAL CSQ_SYMBOL CSQ_Feature CSQ_VARIANT_CLASS CSQ_EXON CSQ_INTRON CSQ_STRAND GT CN NP QA QS QSE QSS",
-        "add_comment_column": true,
-        "summary": "dias"
+        ]
       }
     }
   ]


### PR DESCRIPTION
### eggd_dias_cnvreports_workflow 1.1.0

**Changes**

- eggd_dias_cnvreports_workflow version number updated
- stage IDs renamed; these names are more self-explanatory
- update app versions to newest current version. All apps were already up-to-date except eggd_generate_variant_workbook:
  - eggd_generate_variant_workbook: v2.2.0 > v2.5.0
- move some inputs from the workflow to the config (new config version egg5_dias_CEN_config 2.1.0). The inputs moved are as follows:
      -  stage-cnv_generate_bed_excluded.flank
      -  stage-cnv_generate_workbook.additional_sheet_names
      -  stage-cnv_generate_workbook.exclude_columns
      -  stage-cnv_generate_workbook.reorder_columns
      -  stage-cnv_generate_workbook.add_comment_column
      -  stage-cnv_generate_workbook.summary

**Testing**

Testing and development were done in this project: [https://platform.dnanexus.com/projects/GXx4bg04XZB63XqK9xpPKvy9/monitor](https://platform.dnanexus.com/projects/GXx4bg04XZB63XqK9xpPKvy9/monitor)
The DNAnexus workflow ID of the eggd_dias_cnvreports_workflow 1.1.0 workflow tested is workflow-GXzvJq84XZB1fJk9fBfG88XJ ([link](https://platform.dnanexus.com/panx/projects/GXx4bg04XZB63XqK9xpPKvy9/data/?scope=project&id.values=workflow-GXzvJq84XZB1fJk9fBfG88XJ))
![Screenshot from 2023-07-25 14-58-48](https://github.com/eastgenomics/eggd_dias_cnvreports_workflow/assets/71272357/98c8a1bb-8afb-4450-b1de-24608c7c368f)

**Works for both Epic and Gemini style manifestos**
Example using Epic manifesto: [analysis-GXzvPQ84XZB46JFgJBpYJF4v](https://platform.dnanexus.com/projects/GXx4bg04XZB63XqK9xpPKvy9/monitor/analysis/GXzvPQ84XZB46JFgJBpYJF4v)
Example using Gemini manifesto: [analysis-analysis-GXzvPPj4XZBPfxx6j0yZv53F](https://platform.dnanexus.com/projects/GXx4bg04XZB63XqK9xpPKvy9/monitor/analysis/analysis-GXzvPPj4XZBPfxx6j0yZv53F)
 
**All stages renamed and app versions updated**
`dx describe analysis-GXzvPPj4XZBPfxx6j0yZv53F` and `dx describe analysis-GXzvx104XZBJPXG1bZ438x12` were run to check all the stages in the process had been renamed correctly and use the correct app versions for both Epic and Gemini manifesto styles.
This screenshot shows that the app versions and stage names match the expected updated versions, using an Epic-style manifesto:
![Screenshot from 2023-07-25 15-07-23](https://github.com/eastgenomics/eggd_dias_cnvreports_workflow/assets/71272357/9aeab810-4338-4a7c-8947-a60960403328)
This screenshot shows that the app versions and stage names match the expected updated versions, using a Gemini-style manifesto:
![Screenshot from 2023-07-25 15-04-07](https://github.com/eastgenomics/eggd_dias_cnvreports_workflow/assets/71272357/0cbbfbc7-c6a3-48bd-8659-1067ad8c4bd0)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_cnvreports_workflow/6)
<!-- Reviewable:end -->
