### PR TITLE
DI-691 v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@ DNAnexus workflow to generate bed files, coverage reports and Excel workbooks fo
 
 |               App               | Version |
 | -------------                   | ------------- |
-| generate_bed                    | 1.2.0  |
+| eggd_generate_bed                    | 1.3.0  |
 | eggd_annotate_excluded_regions  | 1.0.1  |
-| generate_bed                    | 1.2.0    |
-| eggd_vep                        | 1.1.0  |
+| eggd_vep                        | 1.3.0  |
 | eggd_additional_cnv_tasks       | 1.0.1  |
-| eggd_generate_variant_workbook  | 2.5.0  |
+| eggd_generate_variant_workbook  | 2.7.1  |
 
 
 This workflow was made by EMEE GLH

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -56,7 +56,7 @@
     },
     {
       "id": "stage-cnv_generate_workbook",
-      "executable": "app-eggd_generate_variant_workbook/2.5.0",
+      "executable": "app-eggd_generate_variant_workbook/2.7.1",
       "input": {
         "vcfs": [
           {

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,6 +1,6 @@
 {
-  "name": "dias_cnvreports_v1.1.0",
-  "title": "dias_cnvreports_v1.1.0",
+  "name": "dias_cnvreports_v1.2.0",
+  "title": "dias_cnvreports_v1.2.0",
   "stages": [
     {
       "id": "stage-cnv_generate_bed_excluded",

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -5,12 +5,12 @@
     {
       "id": "stage-cnv_generate_bed_excluded",
       "name": "generate_bed_for_excluded_annotation",
-      "executable": "app-generate_bed/1.2.0"
+      "executable": "app-eggd_generate_bed/1.3.0"
     },
     {
       "id": "stage-cnv_generate_bed_vep",
       "name": "generate_bed_for_vep",
-      "executable": "app-generate_bed/1.2.0"
+      "executable": "app-eggd_generate_bed/1.3.0"
     },
     {
       "id": "stage-cnv_annotate_excluded_regions",

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -26,7 +26,7 @@
     },
     {
       "id": "stage-cnv_vep",
-      "executable": "app-eggd_vep/1.1.0",
+      "executable": "app-eggd_vep/1.3.0",
       "input": {
         "normalise": false,
         "panel_bed": {


### PR DESCRIPTION
**Changes**
- dxworkflow.json
  - Update name and title from v1.1.0 -> v1.2.0
  - Update apps to their most recent versions:
    - generate_bed v1.2.0 → eggd_generate_bed v1.3.0
    - eggd_vep v1.1.0 → v1.3.0
    - eggd_generate_variant_workbook v2.5.0 → v2.7.1
- README
  - Update app versions to match those in the workflow:
    - generate_bed v1.2.0 → eggd_generate_bed v1.3.0
    - eggd_vep v1.1.0 → v1.3.0
    - eggd_generate_variant_workbook v2.5.0 → v2.7.1

**Testing**
A test job showing the working workflow was run:
- The eggd_dias_cnvreports_workflow was built with workflow ID `workflow-Gg9Ybq841Ky1xfYgQ2qjqG3F` (https://platform.dnanexus.com/panx/projects/Gg9Yb7041Ky713vJ3zkFpJq7/data/?id.constraint=%24or&id.values=workflow-Gg9Ybq841Ky1xfYgQ2qjqG3F).
- A Dias batch CEN config was created to contain this workflow ID (https://platform.dnanexus.com/panx/projects/Gg5Z9VQ4z4Vz8G64byYQbXb6/data/?scope=project&id.values=file-GgF0zB04z4VgB0F46Zzq4kGK) and used to set off the CNV reports (and SNV reports) workflows for two samples, which ran successfully:

Dias batch job:
https://platform.dnanexus.com/panx/projects/Gg5Z9VQ4z4Vz8G64byYQbXb6/monitor/job/GgF11504z4VzfXQvjQjk4P92

Example CNV reports workflow analyses for two samples set off by the above Dias batch job:
- https://platform.dnanexus.com/panx/projects/Gg5Z9VQ4z4Vz8G64byYQbXb6/monitor/analysis/GgF12fj4z4VjF9bygP6GGgVz
- https://platform.dnanexus.com/panx/projects/Gg5Z9VQ4z4Vz8G64byYQbXb6/monitor/analysis/GgF12j04z4Vb3GyvfkxY5gJV

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_cnvreports_workflow/7)
<!-- Reviewable:end -->
