### PR TITLE
update to use 2.8.0 of generate_variant_workbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ DNAnexus workflow to generate bed files, coverage reports and Excel workbooks fo
 | generate_bed                    | 1.2.0    |
 | eggd_vep                        | 1.1.0  |
 | eggd_additional_cnv_tasks       | 1.0.1  |
-| eggd_generate_variant_workbook  | 2.5.0  |
+| eggd_generate_variant_workbook  | 2.8.0  |
 
 
 This workflow was made by EMEE GLH

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,6 +1,6 @@
 {
-  "name": "dias_cnvreports_v1.1.0",
-  "title": "dias_cnvreports_v1.1.0",
+  "name": "dias_cnvreports_v1.1.1",
+  "title": "dias_cnvreports_v1.1.1",
   "stages": [
     {
       "id": "stage-cnv_generate_bed_excluded",
@@ -56,7 +56,7 @@
     },
     {
       "id": "stage-cnv_generate_workbook",
-      "executable": "app-eggd_generate_variant_workbook/2.5.0",
+      "executable": "app-eggd_generate_variant_workbook/2.8.0",
       "input": {
         "vcfs": [
           {


### PR DESCRIPTION
Changes

- Increment version to 1.1.1
- Update eggd_generate_variant_worbook 2.5.0 --> 2.8.0

> [!NOTE]  
> v1.2.0 of dias_reports_workflow has already been merged into main. To avoid conflicts and reverting these changes, v1.1.1 will be merged into a separate release branch to act as main until v1.2.0 is live.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_cnvreports_workflow/9)
<!-- Reviewable:end -->
