### PR TITLE
remove generate bed stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ DNAnexus workflow to generate bed files, coverage reports and Excel workbooks fo
 
 |               App               | Version |
 | -------------                   | ------------- |
-| eggd_generate_bed                    | 1.3.0  |
 | eggd_annotate_excluded_regions  | 1.0.1  |
 | eggd_vep                        | 1.3.0  |
 | eggd_additional_cnv_tasks       | 1.0.1  |

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,40 +1,16 @@
 {
-  "name": "dias_cnvreports_v1.2.0",
-  "title": "dias_cnvreports_v1.2.0",
+  "name": "dias_cnvreports_v1.3.0",
+  "title": "dias_cnvreports_v1.3.0",
   "stages": [
     {
-      "id": "stage-cnv_generate_bed_excluded",
-      "name": "generate_bed_for_excluded_annotation",
-      "executable": "app-eggd_generate_bed/1.3.0"
-    },
-    {
-      "id": "stage-cnv_generate_bed_vep",
-      "name": "generate_bed_for_vep",
-      "executable": "app-eggd_generate_bed/1.3.0"
-    },
-    {
       "id": "stage-cnv_annotate_excluded_regions",
-      "executable": "app-eggd_annotate_excluded_regions/1.0.1",
-      "input": {
-        "panel_bed": {
-          "$dnanexus_link": {
-            "stage": "stage-cnv_generate_bed_excluded",
-            "outputField": "bed_file"
-          }
-        }
-      }
+      "executable": "app-eggd_annotate_excluded_regions/1.0.1"
     },
     {
       "id": "stage-cnv_vep",
       "executable": "app-eggd_vep/1.3.0",
       "input": {
-        "normalise": false,
-        "panel_bed": {
-          "$dnanexus_link": {
-            "stage": "stage-cnv_generate_bed_vep",
-            "outputField": "bed_file"
-          }
-        }
+        "normalise": false
       },
       "systemRequirements": {
         "*": {


### PR DESCRIPTION
The bed files will be the static ones in 001_Ref rather than generating them as part of this workflow

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_cnvreports_workflow/12)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version of the `eggd_generate_bed` application in documentation.
	- Enhanced workflow with updated version `v1.3.0` in the configuration.

- **Bug Fixes**
	- Removed outdated stages from the workflow, streamlining the process.

- **Documentation**
	- Revised README to reflect the new version of the `eggd_generate_bed` application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->