### PR TITLE
revert to 1.2.0 & then add new workbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ DNAnexus workflow to generate bed files, coverage reports and Excel workbooks fo
 | eggd_vep                        | 1.3.0  |
 | eggd_additional_cnv_tasks       | 1.0.1  |
 | eggd_generate_variant_workbook  | 2.10.2  |
+|eggd_generate_bed                | 1.3.0   |
 
 
 This workflow was made by EMEE GLH

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DNAnexus workflow to generate bed files, coverage reports and Excel workbooks fo
 | eggd_annotate_excluded_regions  | 1.0.1  |
 | eggd_vep                        | 1.3.0  |
 | eggd_additional_cnv_tasks       | 1.0.1  |
-| eggd_generate_variant_workbook  | 2.8.2  |
+| eggd_generate_variant_workbook  | 2.10.2  |
 
 
 This workflow was made by EMEE GLH

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -3,14 +3,38 @@
   "title": "dias_cnvreports_v1.2.1",
   "stages": [
     {
+      "id": "stage-cnv_generate_bed_excluded",
+      "name": "generate_bed_for_excluded_annotation",
+      "executable": "app-eggd_generate_bed/1.3.0"
+    },
+    {
+      "id": "stage-cnv_generate_bed_vep",
+      "name": "generate_bed_for_vep",
+      "executable": "app-eggd_generate_bed/1.3.0"
+    },
+    {
       "id": "stage-cnv_annotate_excluded_regions",
-      "executable": "app-eggd_annotate_excluded_regions/1.0.1"
+      "executable": "app-eggd_annotate_excluded_regions/1.0.1",
+      "input": {
+        "panel_bed": {
+          "$dnanexus_link": {
+            "stage": "stage-cnv_generate_bed_excluded",
+            "outputField": "bed_file"
+          }
+        }
+      }
     },
     {
       "id": "stage-cnv_vep",
       "executable": "app-eggd_vep/1.3.0",
       "input": {
-        "normalise": false
+        "normalise": false,
+        "panel_bed": {
+          "$dnanexus_link": {
+            "stage": "stage-cnv_generate_bed_vep",
+            "outputField": "bed_file"
+          }
+        }
       },
       "systemRequirements": {
         "*": {

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,6 +1,6 @@
 {
-  "name": "dias_cnvreports_v1.2.0",
-  "title": "dias_cnvreports_v1.2.0",
+  "name": "dias_cnvreports_v1.2.1",
+  "title": "dias_cnvreports_v1.2.1",
   "stages": [
     {
       "id": "stage-cnv_generate_bed_excluded",
@@ -56,7 +56,7 @@
     },
     {
       "id": "stage-cnv_generate_workbook",
-      "executable": "app-eggd_generate_variant_workbook/2.8.2",
+      "executable": "app-eggd_generate_variant_workbook/2.10.2",
       "input": {
         "vcfs": [
           {


### PR DESCRIPTION
reverted to previous release to retain generate_bed steps and then add new workbooks

as with snv reports, please advise if you'd prefer different version numbers

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_cnvreports_workflow/13)
<!-- Reviewable:end -->
